### PR TITLE
node modules weren't transpiled by babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,0 @@
-{
-  "presets": ["@babel/env", "@babel/typescript"],
-  "plugins": [
-    "@babel/proposal-class-properties",
-
-    "@babel/proposal-object-rest-spread"
-  ]
-}

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,16 @@
+{
+    "presets": [
+        "@babel/typescript"
+    ],
+    "plugins": [
+        "@babel/plugin-transform-exponentiation-operator",
+        "@babel/plugin-transform-regenerator",
+        "@babel/plugin-transform-classes",
+        "@babel/plugin-transform-object-super",
+        "@babel/plugin-transform-async-to-generator",
+        "@babel/proposal-class-properties",
+        "@babel/proposal-object-rest-spread",
+        [ "@babel/plugin-proposal-unicode-property-regex",       { useUnicodeFlag: false }]
+
+    ]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,9 +17,8 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.ts$/,
+        test: /\.(t|j)s$/,
         use: 'babel-loader',
-        exclude: /node_modules/,
       },
     ],
   },


### PR DESCRIPTION
This was a complex issue that required more or less the changes to
webpack and the move of the babel config to fix.

babel.config.json changes are there as on a particular input some
plugins were introducing errors.