### PR TITLE
docs: add archive notice — k6 has native TypeScript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@
 
 </div>
 
+> [!WARNING]
+> **This template is deprecated and this repository is archived.**
+>
+> k6 has native TypeScript support enabled by default since [v0.57.0](https://github.com/grafana/k6/releases/tag/v0.57.0) (released February 2025), so you can run `.ts` test files directly with no bundling step. See the [JavaScript and TypeScript compatibility mode documentation](https://grafana.com/docs/k6/latest/using-k6/javascript-typescript-compatibility-mode/) for the details. The `Babel`/`Webpack` setup described below is no longer necessary; the contents are kept for historical reference only.
+
 This repository provides a scaffolding project to start using TypeScript in your k6 scripts.
 
 ## Rationale


### PR DESCRIPTION
## What

Adds a notice at the top of the README marking this template as deprecated and the repository as archived.

## Why

k6 has native TypeScript support enabled by default since [v0.57.0](https://github.com/grafana/k6/releases/tag/v0.57.0) (February 2025). `.ts` test files can be run directly with no bundling step, so the `Babel`/`Webpack` setup this template demonstrates is no longer necessary.

The notice points users to the [JavaScript and TypeScript compatibility mode docs](https://grafana.com/docs/k6/latest/using-k6/javascript-typescript-compatibility-mode/) and keeps the original content below for historical reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)